### PR TITLE
If there's no public IP on an instance fall back to private

### DIFF
--- a/src/main/scala/com/gu/pentest/Aws.scala
+++ b/src/main/scala/com/gu/pentest/Aws.scala
@@ -49,7 +49,7 @@ object Aws {
       reservation.getInstances.toList.flatMap { instance =>
         for {
           id <- Option(instance.getInstanceId)
-          ip <- Option(instance.getPublicIpAddress)
+          ip <- Option(instance.getPublicIpAddress).orElse(Option(instance.getPrivateIpAddress))
           instanceType <- Option(instance.getInstanceType)
         } yield PenTestInstance(id, ip, instanceType)
       }


### PR DESCRIPTION
This prevents instances without a public IP address from being excluded.
