### PR TITLE
Add warning about invalid instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ The project uses the AWS credentials file so you should provide a
 profile to choose which account to use (just as you would when using
 the AWS CLI tool). More info is available in the
 [AWS CLI documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html).
-Note that the credentials attached to this profile will need
-permission to perform `autoscaling:DescribeAutoScalingGroups` and
-`ec2:DescribeInstances` actions.
+Note that the credentials attached to this profile will need at
+least the following permissions:
+
+* `autoscaling:DescribeAutoScalingGroups`
+* `ec2:DescribeInstances`
 
 The second argument is the AWS region to use when checking for AS
 groups and instances. This defaults to eu-west-1 for our (The
@@ -63,6 +65,16 @@ pen test form. It will look a little like the following:
 
 These are the three form fields that are tedious to fill in. You'll
 still need to get the details for the other fields.
+
+### Invalid instances
+
+AWS does not allow penetration testing to be performed on t1.small,
+t1.medium or t2.nano instance types. If you attempt to submit a request
+when these instance types are in use you'll be presented with a warning.
+This will describe which AutoScaling Groups are affected and which
+instances caused the problem. The affected instances will nto be
+included in the request and any AutoScaling Groups that have no valid
+instances will also be skipped.
 
 ## Development / alternate usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,11 @@ scalaVersion := "2.11.6"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.9.3",
   "com.github.scopt" %% "scopt" % "3.3.0",
+  "joda-time" % "joda-time" % "2.9.4",
+  "org.joda" % "joda-convert" % "1.8",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 
 assemblyJarName in assembly := "pen-test-form.jar"
+
+scalacOptions := Seq("-unchecked", "-deprecation")

--- a/src/main/scala/com/gu/pentest/Aws.scala
+++ b/src/main/scala/com/gu/pentest/Aws.scala
@@ -1,5 +1,7 @@
 package com.gu.pentest
 
+import java.util.{Timer, TimerTask}
+
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Region
@@ -10,7 +12,9 @@ import com.amazonaws.services.ec2.model.{DescribeInstancesRequest, DescribeInsta
 import com.gu.pentest.util.AwsTools
 
 import scala.collection.JavaConversions._
-import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Future, Promise}
+import scala.util.Success
 
 
 object Aws {
@@ -43,6 +47,7 @@ object Aws {
   }
 
   // Tools
+  val ineligbleInstanceTypes = Set("t1.micro", "m1.small", "t2.nano")
 
   def getInstances(instancesResult: DescribeInstancesResult): List[PenTestInstance] = {
     instancesResult.getReservations.toList.flatMap { reservation =>
@@ -65,12 +70,30 @@ object Aws {
   }
 
   def getPenTestDetails(asGroups: List[PenTestAsGroup], instances: List[PenTestInstance]): Map[String, List[PenTestInstance]] = {
-    val asGroupsMap = asGroups.map { asGroup =>
-      asGroup.name -> asGroup.instanceIds.flatMap(instanceId => instances.filter(filterInstance).find(_.id == instanceId))
-    }.toMap
-    asGroupsMap.filter(_._2.nonEmpty)
+    val validInstances = instances.filter(validInstanceType)
+    val validInstanceIds = validInstances.map(_.id)
+
+    (for {
+      asGroup <- asGroups
+        if asGroup.instanceIds.exists(validInstanceIds.contains)
+      instanceId <- asGroup.instanceIds
+      validAsGroupInstances = validInstances.filter(instance => asGroup.instanceIds.contains(instance.id))
+    } yield asGroup.name -> validAsGroupInstances).toMap
   }
 
-  def filterInstance(instance: PenTestInstance): Boolean =
-    !Set("t1.micro", "m1.small").contains(instance.instanceType)
+  def warnings(asGroups: List[PenTestAsGroup], instances: List[PenTestInstance]): Map[PenTestAsGroup, List[PenTestInstance]] = {
+    val invalidInstances = instances.filterNot(validInstanceType)
+    val invalidInstanceIds = invalidInstances.map(_.id)
+
+    (for {
+      asGroup <- asGroups
+        if asGroup.instanceIds.exists(invalidInstanceIds.contains)
+    } yield {
+      asGroup -> invalidInstances.filter(instance => asGroup.instanceIds.contains(instance.id))
+    }).toMap
+  }
+
+  def validInstanceType(instance: PenTestInstance): Boolean = {
+    !ineligbleInstanceTypes.contains(instance.instanceType)
+  }
 }

--- a/src/main/scala/com/gu/pentest/Main.scala
+++ b/src/main/scala/com/gu/pentest/Main.scala
@@ -25,7 +25,10 @@ object Main {
           asGroups = Aws.getAsGroups(asGroupsResult)
           details = Aws.getPenTestDetails(asGroups, instances)
           output = Output.detailsAsString(details)
+          warningsDetails = Aws.warnings(asGroups, instances)
+          warningOutput = Output.warningsAsString(warningsDetails)
         } {
+          System.err.println(Console.YELLOW + warningOutput + Console.RESET)
           println(output)
           System.exit(0)
         }

--- a/src/main/scala/com/gu/pentest/Main.scala
+++ b/src/main/scala/com/gu/pentest/Main.scala
@@ -28,8 +28,8 @@ object Main {
           warningsDetails = Aws.warnings(asGroups, instances)
           warningOutput = Output.warningsAsString(warningsDetails)
         } {
-          System.err.println(Console.YELLOW + warningOutput + Console.RESET)
           println(output)
+          System.err.println(Console.YELLOW + warningOutput + Console.RESET)
           System.exit(0)
         }
 

--- a/src/main/scala/com/gu/pentest/Main.scala
+++ b/src/main/scala/com/gu/pentest/Main.scala
@@ -43,10 +43,10 @@ object Main {
     arg[String]("region") optional() validate { region =>
       try {
         Region.getRegion(Regions.fromName(region))
-        Right()
+        success
       } catch {
         case e: IllegalArgumentException =>
-          Left(s"Invalid AWS region name, $region")
+          failure(s"Invalid AWS region name, $region")
       }
     } action { (region, arguments) =>
       arguments.copy(region = Region.getRegion(Regions.fromName(region)))

--- a/src/main/scala/com/gu/pentest/Output.scala
+++ b/src/main/scala/com/gu/pentest/Output.scala
@@ -5,12 +5,13 @@ import org.joda.time.format.DateTimeFormat
 
 object Output {
   def warningsAsString(details: Map[PenTestAsGroup, List[PenTestInstance]]): String = {
-    val asGroupsText = details.toList.map { case (asGroup, instances) =>
+    if (details.isEmpty) ""
+    else {
+      val asGroupsText = details.toList.map { case (asGroup, instances) =>
       s"""AutoScaling Group:
          |${asGroup.name}
          |Instances:
-         |${instances.map(instanceWarning).mkString("\n")}
-       """.stripMargin
+         |${instances.map(instanceWarning).mkString("\n")}""".stripMargin
     } mkString "\n\n"
 
     s"""Some AutoScaling groups contain instances that are not eligible for pen testing.
@@ -20,8 +21,8 @@ object Output {
        |You should either temporarily change these instances to allowed instance types
        |or be aware that these will be out-of-scope for the pen-test.
        |
-       |$asGroupsText
-     """.stripMargin
+       |$asGroupsText""".stripMargin
+    }
   }
 
   private def instanceWarning(instance: PenTestInstance): String = {

--- a/src/main/scala/com/gu/pentest/Output.scala
+++ b/src/main/scala/com/gu/pentest/Output.scala
@@ -1,6 +1,33 @@
 package com.gu.pentest
 
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+
 object Output {
+  def warningsAsString(details: Map[PenTestAsGroup, List[PenTestInstance]]): String = {
+    val asGroupsText = details.toList.map { case (asGroup, instances) =>
+      s"""AutoScaling Group:
+         |${asGroup.name}
+         |Instances:
+         |${instances.map(instanceWarning).mkString("\n")}
+       """.stripMargin
+    } mkString "\n\n"
+
+    s"""Some AutoScaling groups contain instances that are not eligible for pen testing.
+       |AWS does not allow pen-testing on the following instance types:
+       |${Aws.ineligbleInstanceTypes.mkString(", ")}
+       |
+       |You should either temporarily change these instances to allowed instance types
+       |or be aware that these will be out-of-scope for the pen-test.
+       |
+       |$asGroupsText
+     """.stripMargin
+  }
+
+  private def instanceWarning(instance: PenTestInstance): String = {
+    s"${instance.id} of type ${instance.instanceType}"
+  }
+
   def detailsAsString(details: Map[String, List[PenTestInstance]]): String = {
     val instanceIps = details.values.flatten.map(_.ip).mkString("\n")
     val instanceIds = details.values.flatten.map(_.id).mkString("\n")
@@ -10,6 +37,9 @@ object Output {
       s"$asGroup\n$asInstances"
     } mkString "\n\n"
 
+    val future = DateTime.now().plusDays(90)
+    val format = DateTimeFormat.forPattern("yyyy-MM-dd")
+
     s"""Instance IDs:
        |$instanceIds
        |
@@ -17,9 +47,13 @@ object Output {
        |$instanceIps
        |
        |Comments:
-       |Here are full details of the AS groups and current instances. The actual instances will change during routine scaling and deployments.
+       |Here are full details of the AS groups and current instances.
+       |The actual instances will change during routine scaling and deployments.
        |
        |$comments
+       |
+       |End date:
+       |${format.print(future)} 00:00
      """.stripMargin
   }
 }

--- a/src/test/scala/com/gu/pentest/AwsTest.scala
+++ b/src/test/scala/com/gu/pentest/AwsTest.scala
@@ -2,17 +2,20 @@ package com.gu.pentest
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers, OptionValues}
 
-class AwsTest extends FreeSpec with Matchers with OptionValues with ScalaFutures {
+class AwsTest extends FreeSpec with Matchers with OptionValues with ScalaFutures with BeforeAndAfterAll {
   implicit val defaultPatience =
     PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
 
-  "getPenTestDetails" - {
-    val instance1 = PenTestInstance("id1", "1.1.1.1", "t2.medium")
-    val instance2 = PenTestInstance("id2", "1.1.1.2", "t2.medium")
-    val instance3 = PenTestInstance("id3", "1.1.1.3", "t2.medium")
+  val instance1 = PenTestInstance("id1", "1.1.1.1", "t2.medium")
+  val instance2 = PenTestInstance("id2", "1.1.1.2", "t2.medium")
+  val instance3 = PenTestInstance("id3", "1.1.1.3", "t2.medium")
+  val nano = PenTestInstance("id-nano", "1.1.1.4", "t2.nano")
+  val t1Micro = PenTestInstance("id-micro", "1.1.1.5", "t1.micro")
+  val m1Small = PenTestInstance("id-small", "1.1.1.6", "m1.small")
 
+  "getPenTestDetails" - {
     "returns an empty map if there are no AS groups" in {
       Aws.getPenTestDetails(Nil, Nil) shouldEqual Map.empty
     }
@@ -40,31 +43,56 @@ class AwsTest extends FreeSpec with Matchers with OptionValues with ScalaFutures
       result shouldNot contain key "as2"
     }
 
+    "excludes t2.nano instance types" in {
+      val instances = List(instance1, nano)
+      val asGroups = List(PenTestAsGroup("as1", instances.map(_.id)))
+      Aws.getPenTestDetails(asGroups, instances).get("as1").value.map(_.instanceType) should not contain "t2.nano"
+    }
+
     "excludes m1.small instance types" in {
-      val instances = List(
-        instance1,
-        PenTestInstance("id-small", "1.1.1.1", "m1.small")
-      )
-      val asGroups = List(PenTestAsGroup("as1", List("id1", "id-small")))
+      val instances = List(instance1, m1Small)
+      val asGroups = List(PenTestAsGroup("as1", instances.map(_.id)))
       Aws.getPenTestDetails(asGroups, instances).get("as1").value.map(_.instanceType) should not contain "m1.small"
     }
 
     "excludes t1.micro instance types" in {
-      val instances = List(
-        instance1,
-        PenTestInstance("id-micro", "1.1.1.1", "t1.micro")
-      )
-      val asGroups = List(PenTestAsGroup("as1", List("id1", "id-micro")))
+      val instances = List(instance1, t1Micro)
+      val asGroups = List(PenTestAsGroup("as1", instances.map(_.id)))
       Aws.getPenTestDetails(asGroups, instances).get("as1").value.map(_.instanceType) should not contain "t1.micro"
     }
 
     "excludes as groups that contain only excluded instance types" in {
-      val instances = List(
-        PenTestInstance("id-small", "1.1.1.1", "m1.small"),
-        PenTestInstance("id-micro", "1.1.1.1", "t1.micro")
-      )
-      val asGroups = List(PenTestAsGroup("as1", List("id-small", "id-micro")))
+      val instances = List(m1Small, t1Micro)
+      val asGroups = List(PenTestAsGroup("as1", instances.map(_.id)))
       Aws.getPenTestDetails(asGroups, instances) shouldBe 'empty
+    }
+  }
+
+  "warnings" - {
+    "does not include an AS group with no invalid instances" in {
+      val instances = List(instance1, instance2)
+      val asGroups = List(PenTestAsGroup("as1", instances.map(_.id)))
+      Aws.warnings(asGroups, instances) shouldEqual Map.empty
+    }
+
+    "given an AS group with invalid instances" - {
+      val instances = List(instance1, nano, t1Micro)
+      val asGroup = PenTestAsGroup("as1", instances.map(_.id))
+
+      "includes that group in its returned groups" in {
+        Aws.warnings(List(asGroup), instances).keySet.map(_.name) should contain("as1")
+      }
+
+      "returns all invalid instances for an AS group" in {
+        val invalidInstances = Aws.warnings(List(asGroup), instances).get(asGroup).value
+        invalidInstances should contain(nano)
+        invalidInstances should contain(t1Micro)
+      }
+
+      "does not include valid instances in the warnings" in {
+        val invalidInstances = Aws.warnings(List(asGroup), instances).get(asGroup).value
+        invalidInstances shouldNot contain(instance1)
+      }
     }
   }
 }


### PR DESCRIPTION
If you try and submit a pen test form with invalid instance types you'll now get a nice warning. This makes it easy to chase up potential problem areas before submitting the request.

Also adds t2.nano to disallowed pen test instance types.

cc @kenoir
